### PR TITLE
Swift package update for Swift 5.2 (xcode 11.4.1)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,17 +6,8 @@
         "repositoryURL": "https://github.com/f-meloni/danger-swift-coverage",
         "state": {
           "branch": null,
-          "revision": "104ded872b6e1af1def04b897bc3a29fe04865ba",
-          "version": "0.3.0"
-        }
-      },
-      {
-        "package": "Files",
-        "repositoryURL": "https://github.com/JohnSundell/Files.git",
-        "state": {
-          "branch": null,
-          "revision": "a84615f4558151fab52ac38df697ce2442991f93",
-          "version": "2.3.0"
+          "revision": "f8dbe265ea8d8d2936d861bff10ea280b742d237",
+          "version": "1.1.0"
         }
       },
       {
@@ -29,30 +20,12 @@
         }
       },
       {
-        "package": "Marathon",
-        "repositoryURL": "https://github.com/JohnSundell/Marathon",
-        "state": {
-          "branch": null,
-          "revision": "582505bbd8e782c7d8812f4c6d356ad19d5222a8",
-          "version": "3.2.0"
-        }
-      },
-      {
         "package": "OctoKit",
         "repositoryURL": "https://github.com/nerdishbynature/octokit.swift",
         "state": {
           "branch": null,
-          "revision": "b63f2ec1b55f26c8e94159d81ad695aeb92f3d4e",
-          "version": "0.9.0"
-        }
-      },
-      {
-        "package": "Releases",
-        "repositoryURL": "https://github.com/JohnSundell/Releases.git",
-        "state": {
-          "branch": null,
-          "revision": "ea62f33a429185b0ed21344c2355862c5bc4fcce",
-          "version": "4.0.0"
+          "revision": "c391cfba4d33f3f4c7d7d8fa6708970f7d30af82",
+          "version": "0.10.1"
         }
       },
       {
@@ -60,17 +33,8 @@
         "repositoryURL": "https://github.com/nerdishbynature/RequestKit.git",
         "state": {
           "branch": null,
-          "revision": "defcc7cb005995f261b47e357874a539f3b5c679",
-          "version": "2.3.0"
-        }
-      },
-      {
-        "package": "Require",
-        "repositoryURL": "https://github.com/JohnSundell/Require.git",
-        "state": {
-          "branch": null,
-          "revision": "7cfbd0d8a2dede0e01f6f0d8ab2c7acef1df112e",
-          "version": "2.0.1"
+          "revision": "fd5e9e99aada7432170366c9e95967011ce13bad",
+          "version": "2.4.0"
         }
       },
       {
@@ -78,8 +42,8 @@
         "repositoryURL": "https://github.com/JohnSundell/ShellOut",
         "state": {
           "branch": null,
-          "revision": "d3d54ce662dfee7fef619330b71d251b8d4869f9",
-          "version": "2.2.0"
+          "revision": "e1577acf2b6e90086d01a6d5e2b8efdaae033568",
+          "version": "2.3.0"
         }
       },
       {
@@ -87,8 +51,17 @@
         "repositoryURL": "https://github.com/danger/swift.git",
         "state": {
           "branch": null,
-          "revision": "ba19f9f950457908355c739946243494a8d202e3",
-          "version": "1.5.6"
+          "revision": "e5364bd91e21d5a1526ec5ac1fdd83d28743fe94",
+          "version": "3.3.0"
+        }
+      },
+      {
+        "package": "Version",
+        "repositoryURL": "https://github.com/mxcl/Version",
+        "state": {
+          "branch": null,
+          "revision": "200046c93f6d5d78a6d72bfd9c0b27a95e9c0a2b",
+          "version": "1.2.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,9 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/danger/swift.git", from: "1.0.0"),
+        .package(url: "https://github.com/danger/swift.git", from: "3.3.0"),
         .package(url: "https://github.com/JohnSundell/ShellOut", from: "2.1.0"),
-        .package(url: "https://github.com/f-meloni/danger-swift-coverage", from: "0.3.0")
+        .package(url: "https://github.com/f-meloni/danger-swift-coverage", from: "1.1.0")
         // Dev dependencies
     ],
     targets: [


### PR DESCRIPTION
Needed as part of the Xcode 11.4.1 migration. Errors when building OctoKit otherwise.